### PR TITLE
Add github action for automated submission

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,18 @@
+name: "submit"
+on:
+  workflow_dispatch:
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm install
+      - name: Build package
+        run: npm run build
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          archive: "web-ext-artifacts/tweak_new_twitter-{version}.zip"
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ locales/js/*.js
 locales/locales.js
 node_modules/
 web-ext-artifacts/
+keys.json


### PR DESCRIPTION
Hi @insin!

Thanks for making this extension, it made twitter much more usable for me :D I was looking for way to contribute, and found that since your codebase doesn't have automated submission, I thought adding that might be helpful. I created a github action called [bpp](https://browser.market) that can submit the zip to the web stores automatically for you. It is set to run manually from the github action tab, but we can tweak it to run as frequent as you wish! The only thing you would need to create is a `SUBMIT_KEYS` github repository secret.

This secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/v1/keys.schema.json).

Here's a sample key:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "extId": "123",
    "apiKey": "abcd",
    "apiSecret": "abcd"
  },
 "edge": {
    "extId": "123",
    "cookie": "abcd"
 }
}

```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)