### PR TITLE
Added setting to allow users to hide Promoted Tweets

### DIFF
--- a/options.html
+++ b/options.html
@@ -55,6 +55,12 @@
           <input type="checkbox" name="hideMoreTweets">
         </label>
       </section>
+      <section class="checkbox">
+        <label>
+          Hide "Promoted" tweets
+          <input type="checkbox" name="hidePromotedTweets">
+        </label>
+      </section>
     </section>
     <section class="group">
       <label>

--- a/options.js
+++ b/options.js
@@ -52,6 +52,7 @@ const defaultConfig = {
   hideVerifiedNotificationsTab: true,
   hideViews: true,
   hideWhoToFollowEtc: true,
+  hidePromotedTweets: false,
   likedTweets: 'ignore',
   mutableQuoteTweets: true,
   mutedQuotes: [],
@@ -170,6 +171,7 @@ function applyConfig() {
       'hideExplorePageContents',
       'hideMoreTweets',
       'hideWhoToFollowEtc',
+      'hidePromotedTweets',
       desktop && 'hideSidebarContent',
     ].filter(Boolean),
     uiImprovements: [

--- a/tweak-new-twitter.user.js
+++ b/tweak-new-twitter.user.js
@@ -67,6 +67,7 @@ const config = {
   hideVerifiedNotificationsTab: true,
   hideViews: true,
   hideWhoToFollowEtc: true,
+  hidePromotedTweets: false,
   likedTweets: 'ignore',
   mutableQuoteTweets: true,
   mutedQuotes: [],
@@ -2981,6 +2982,8 @@ function shouldHideMainTimelineItem(type, page) {
       return config.hideUnavailableQuoteTweets || shouldHideSharedTweet(config.quoteTweets, page)
     case 'UNAVAILABLE_RETWEET':
       return config.hideUnavailableQuoteTweets || shouldHideSharedTweet(config.retweets, page)
+    case 'PROMOTED_TWEET':
+      return config.hidePromotedTweets
     default:
       return true
   }

--- a/types.d.ts
+++ b/types.d.ts
@@ -42,6 +42,7 @@ export type Config = {
   hideVerifiedNotificationsTab: boolean
   hideViews: boolean
   hideWhoToFollowEtc: boolean
+  hidePromotedTweets: boolean
   likedTweets: AlgorithmicTweetsConfig
   mutableQuoteTweets: boolean
   mutedQuotes: QuotedTweet[]


### PR DESCRIPTION
First, this is a great plugin. I learned about it in the Japanese media and it has made my Twitter experience better. Thank you.

--

This pull request allows promotional tweets that are currently hidden by default to be activated from the settings window.

Promoted tweets are offensive to many users, but they represent over 90% of Twitter's revenue stream.

https://www.businessofapps.com/data/twitter-statistics/

I don't want to see offensive tweets from Twitter's low-quality algorithms. But I also don't want Twitter to go bankrupt due to lost revenue from ad blockers.

This feature helps users like me and avoids Twitter banning users for using this extension.

Dirty features like ad blocking should be left to dedicated extensions for that purpose.

--

I did not edit the README because I felt that I should not advertise the ad-blocking features of this extension. The same reason this feature is disabled by default.

However, these choices should be made by the project owner. 

Thank you.