### PR TITLE
Fix disable-timeline on desktop

### DIFF
--- a/script.js
+++ b/script.js
@@ -2691,10 +2691,7 @@ async function addToggleListRetweetsMenuItem($switchMenuItem) {
 function checkforDisabledHomeTimeline() {
   if (config.disableHomeTimeline && location.pathname == '/home') {
     log(`home timeline disabled, redirecting to /${config.disabledHomeTimelineRedirect}`)
-    let primaryNavSelector = desktop ? Selectors.PRIMARY_NAV_DESKTOP : Selectors.PRIMARY_NAV_MOBILE
-    ;/** @type {HTMLElement} */ (
-      document.querySelector(`${primaryNavSelector} a[href="/${config.disabledHomeTimelineRedirect}"]`)
-    ).click()
+    setTimeout(() => location.href = `/${config.disabledHomeTimelineRedirect}`, 100)
     return true
   }
 }


### PR DESCRIPTION
# Issue
"Disable timeline" wasn't working properly on the desktop. Redirecting to twitter.com lands on "/home" instead of redirecting to `disableTimelineRedirect`.

# Cause
It was caused by unable to locate the "disableTimelineRedirect" most likely due to a rendering timing issue.

<details><summary>error I found when I was debugging locally</summary>
<p>
<img width="569" alt="截屏2024-04-10 下午9 46 24" src="https://github.com/insin/control-panel-for-twitter/assets/81038/c2d2970f-5376-4260-b732-953547fe9aae">
</p>
</details> 

# Solution
Add setTimeout, I also try to make the redirect straightforward: instead of locating the link, why can't we just redirect to the path? Let me know if this impacts other observer behaviours.