### PR TITLE
Add support for full-width profiles and posts

### DIFF
--- a/script.js
+++ b/script.js
@@ -1695,7 +1695,7 @@ const THEME_COLORS = new Map([
   ['green500', 'rgb(0, 186, 124)'],
 ])
 // <body> pseudo-selector for pages the full-width content feature works on
-const FULL_WIDTH_BODY_PSEUDO = ':is(.Community, .List, .HomeTimeline, .Profile)'
+const FULL_WIDTH_BODY_PSEUDO = ':is(.Community, .List, .HomeTimeline, .Profile, .Tweet)'
 // Matches any notification count at the start of the title
 const TITLE_NOTIFICATION_RE = /^\(\d+\+?\) /
 // The Communities nav item takes you to /yourusername/communities

--- a/script.js
+++ b/script.js
@@ -1695,7 +1695,7 @@ const THEME_COLORS = new Map([
   ['green500', 'rgb(0, 186, 124)'],
 ])
 // <body> pseudo-selector for pages the full-width content feature works on
-const FULL_WIDTH_BODY_PSEUDO = ':is(.Community, .List, .HomeTimeline)'
+const FULL_WIDTH_BODY_PSEUDO = ':is(.Community, .List, .HomeTimeline, .Profile)'
 // Matches any notification count at the start of the title
 const TITLE_NOTIFICATION_RE = /^\(\d+\+?\) /
 // The Communities nav item takes you to /yourusername/communities
@@ -3372,6 +3372,10 @@ const configureCss = (() => {
           body.Sidebar${FULL_WIDTH_BODY_PSEUDO} ${Selectors.PRIMARY_COLUMN} > div:first-child > div:last-child {
             max-width: 990px;
           }
+          /* Force full width on Profiles when sidebar is visible */
+          body.Sidebar.Profile ${Selectors.PRIMARY_COLUMN} > div:first-child > div:last-child > div:first-child > div:first-child {
+            max-width: unset;
+          }
           /* Make the "What's happening" input keep its original width */
           body.HomeTimeline ${Selectors.PRIMARY_COLUMN} > div:first-child > div:nth-of-type(3) div[role="progressbar"] + div {
             max-width: 598px;
@@ -3389,6 +3393,10 @@ const configureCss = (() => {
           }
           body:not(.Sidebar)${FULL_WIDTH_BODY_PSEUDO} ${Selectors.PRIMARY_COLUMN} > div:first-child > div:first-child div,
           body:not(.Sidebar)${FULL_WIDTH_BODY_PSEUDO} ${Selectors.PRIMARY_COLUMN} > div:first-child > div:last-child {
+            max-width: unset;
+          }
+          /* Force full width on Profiles when sidebar is not visible */
+          body.not(.Sidebar).Profile ${Selectors.PRIMARY_COLUMN} > div:first-child > div:last-child > div:first-child > div:first-child {
             max-width: unset;
           }
         `)


### PR DESCRIPTION
Thank you for this extension, it's been very useful for me personally so I wanted to try my hand at some stuff.

This PR fixes #367 to keep the full-width mode a bit more consistent.

<details>
<summary>Images attached for reference.</summary>
<img src="https://github.com/user-attachments/assets/6e967c6c-ae67-4a95-9313-8bc3d2780fa2" width="500">
<img src="https://github.com/user-attachments/assets/b45bd794-0fde-460c-9282-3e3e24ff43d6" width="500">
<img src="https://github.com/user-attachments/assets/9721d423-4f97-4cfd-a21e-026c6fb1ffe5" width="500">
</details>