### PR TITLE
Update Japanese translation in tweet box

### DIFF
--- a/script.js
+++ b/script.js
@@ -1067,7 +1067,7 @@ const locales = {
     TWEET_YOUR_REPLY: '返信をツイートしましょう。',
     UNDO_RETWEET: 'リツイートを取り消す',
     VIEW: '表示する',
-    WHATS_HAPPENING: '何が起こっているの？',
+    WHATS_HAPPENING: 'いまどうしてる？',
   },
   kn: {
     ADD_ANOTHER_TWEET: 'ಮತ್ತೊಂದು ಟ್ವೀಟ್ ಸೇರಿಸಿ',

--- a/scripts/locales/base-locales.json
+++ b/scripts/locales/base-locales.json
@@ -574,7 +574,7 @@
     "TWEET_YOUR_REPLY": "返信をツイートしましょう。",
     "UNDO_RETWEET": "リツイートを取り消す",
     "VIEW": "表示する",
-    "WHATS_HAPPENING": "何が起こっているの？"
+    "WHATS_HAPPENING": "いまどうしてる？"
   },
   "kn": {
     "ADD_ANOTHER_TWEET": "ಮತ್ತೊಂದು ಟ್ವೀಟ್ ಸೇರಿಸಿ",


### PR DESCRIPTION
### Summary
- Updated Japanese translation in `script.js` and `scripts/locales/base-locales.json`
- Changed `"何が起こっているの？"` to `"いまどうしてる？"`

### Why
- The previous translation ("何が起こっているの？") is not incorrect but does not reflect the actual wording used in the Japanese version of Twitter.
- Twitter Japan has historically used `"いまどうしてる？"` as the standard phrase for the tweet input box.
- This change ensures consistency with the platform’s official localization.

### Files Changed
- `script.js`
- `scripts/locales/base-locales.json`
