### PR TITLE
Fix Japanese translation for reply box placeholder

### DIFF
--- a/script.js
+++ b/script.js
@@ -1067,7 +1067,7 @@ const locales = {
     TWEETS: 'ツイート',
     TWEET_ALL: 'すべてツイート',
     TWEET_INTERACTIONS: 'ツイートの相互作用',
-    TWEET_YOUR_REPLY: '返信をツイートしましょう',
+    TWEET_YOUR_REPLY: '返信をツイート',
     UNDO_RETWEET: 'リツイートを取り消す',
     VIEW: '表示する',
     WHATS_HAPPENING: 'いまどうしてる？',

--- a/scripts/locales/base-locales.json
+++ b/scripts/locales/base-locales.json
@@ -574,7 +574,7 @@
     "TWEETS": "ツイート",
     "TWEET_ALL": "すべてツイート",
     "TWEET_INTERACTIONS": "ツイートの相互作用",
-    "TWEET_YOUR_REPLY": "返信をツイートしましょう",
+    "TWEET_YOUR_REPLY": "返信をツイート",
     "UNDO_RETWEET": "リツイートを取り消す",
     "VIEW": "表示する",
     "WHATS_HAPPENING": "いまどうしてる？"


### PR DESCRIPTION
### Summary
- Corrected the Japanese translation for the reply box placeholder

### Why
- The previous translation added an unnecessary phrase ("しましょう"), while the correct and official wording on Twitter is simply `"返信をツイート"`

### Files Changed
- `scripts/locales/base-locales.json`
- `script.js`
