### PR TITLE
Fix Japanese translation wording and sentence endings

### DIFF
--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -99,7 +99,7 @@
     "message": "すべて非表示"
   },
   "hideBlueReplyFollowedByLabel": {
-    "message": "私をフォローしている人を非表示にします"
+    "message": "私をフォローしている人を非表示にする"
   },
   "hideBlueReplyFollowingLabel": {
     "message": "フォローしている人を非表示にする"
@@ -150,7 +150,7 @@
     "message": "タイムライン内のインラインプロンプトを非表示にする"
   },
   "hideJobsLabel": {
-    "message": "募集を隠す"
+    "message": "募集を非表示にする"
   },
   "hideLikeMetricsLabel": {
     "message": "いいね件数"
@@ -219,7 +219,7 @@
     "message": "スペースを作成"
   },
   "hideSubscriptionsLabel": {
-    "message": "サブスクリプションを非表示"
+    "message": "サブスクリプションを非表示にする"
   },
   "hideTimelineTweetBoxLabel": {
     "message": "タイムラインのツイートボックス"
@@ -336,13 +336,13 @@
     "message": "X のブランド変更を置き換える"
   },
   "restoreLinkHeadlinesLabel": {
-    "message": "外部リンクの下に見出しを復元"
+    "message": "外部リンクの下に見出しを復元する"
   },
   "restoreOtherInteractionLinksLabel": {
     "message": "ツイートの下の他のリンクを復元する"
   },
   "restoreQuoteTweetsLinkLabel": {
-    "message": "ツイートの下にある「引用ツイート」リンクを復元し"
+    "message": "ツイートの下にある「引用ツイート」リンクを復元する"
   },
   "retweetsLabel": {
     "message": "リツイート"


### PR DESCRIPTION
I made terms consistent in my pr commit. 

Environments
Control panel for twitter version: v4.9.0
Brave version: 1.75.181 Chromium: 133.0.6943.141 Official Build 64bit

1. Line102: `~非表示にします` -> `~非表示にする`.
2. Line153: `募集を隠す` -> `募集を非表示にする`. In English localization, other `hide~`s are translated to `~非表示にする`. So, they should be consistent.
3. Line222: `~を非表示` -> `~非表示にする`.
4. Line339: `~を復元` -> `~を復元する`.
5. Line345: `~を復元し` -> `~を復元する`.

Below it, you can check them at a glance in the pictures. Sorry for handwriting. Thank you.

![fix-ja-translation-pr-1-by-rako](https://github.com/user-attachments/assets/12baba5b-639f-4e2b-9d14-086041730267)
![fix-ja-translation-pr-2-by-rako](https://github.com/user-attachments/assets/8510567f-ffdd-417d-8558-d4188345cb46)
