### PR TITLE
fix: location label no longer displaying undefined for web users

### DIFF
--- a/script.js
+++ b/script.js
@@ -3637,6 +3637,7 @@ async function addAccountLocationToFocusedTweet($permalinkBar, screenName) {
   if (!screenName) return
   let accountLocation = await getAccountLocation(screenName)
   if (!accountLocation) return
+  if (accountLocation.account_based_in === undefined) return;
   let $separator = document.createElement('span')
   $separator.className = 'AccountLocation cpft_separator cpft_text'
   $separator.setAttribute('aria-hidden', 'true')


### PR DESCRIPTION
if a user is only logged in via web, they won't have any location data, yet the `accountLocation` object is still there when fetching the profile info

we're only using `accountLocation.account_based_in` for the raw location text, but that isn't there in the object when its a web exclusive user, meaning its undefined 

this just adds another return statement to check if it's undefined

```json
{
  "learn_more_url": "https://help.twitter.com/rules-and-policies/profile-labels",
  "source": "Web",
  "username_changes": {
    "count": "0"
  }
}
```

<img width="261" height="175" alt="{4E6414A3-4020-434C-BE65-35D97AB3F463}" src="https://github.com/user-attachments/assets/de35eb0c-3af5-4366-a21e-f3bdba34947a" />
<img width="491" height="86" alt="{CA784B23-8FFD-4622-B9AC-54BD0827DFC0}" src="https://github.com/user-attachments/assets/c97618b9-e3fa-4891-8488-06cee80a1cd4" />
