### PR TITLE
Fix Explore tab showing in mobile nav when disabled

### DIFF
--- a/script.js
+++ b/script.js
@@ -5208,6 +5208,9 @@ const configureCss = (() => {
           `body.Explore ${Selectors.TIMELINE}`,
         )
       }
+      if (config.hideExploreNav) {
+        hideCssSelectors.push(`${Selectors.PRIMARY_NAV_MOBILE} a[href="/explore"]`)
+      }
       if (config.hideGrokNav) {
         hideCssSelectors.push(`${Selectors.PRIMARY_NAV_MOBILE} a[href="/i/grok"]`)
       }


### PR DESCRIPTION
Fixes #868

When the Explore tab is disabled in settings, it was hidden in the desktop nav (`header nav`) but not in the mobile nav (`#layers nav`). This meant it still appeared on pages like Messages when viewed on mobile.

Added the missing `PRIMARY_NAV_MOBILE` selector for Explore, following the same pattern used by the other nav items (Grok, Communities, Jobs, etc. all have both desktop and mobile selectors).